### PR TITLE
feat: add processing as a success status

### DIFF
--- a/gr4vy-iOS/Gr4vyUtility.swift
+++ b/gr4vy-iOS/Gr4vyUtility.swift
@@ -98,7 +98,7 @@ struct Gr4vyUtility {
         
         switch status {
             // Success statuses
-        case "capture_succeeded", "capture_pending", "authorization_succeeded", "authorization_pending":
+        case "capture_succeeded", "capture_pending", "authorization_succeeded", "authorization_pending", "processing":
             guard let transactionID = data["id"] as? String else {
                 return .generalError("Gr4vy Error: transaction success has failed, no transactionID and/or paymentMethodID found")
             }


### PR DESCRIPTION
`processing` can be returned as a success status for push payments (outside of Gr4vy checkout).