### PR TITLE
chore: make WebView inspectable

### DIFF
--- a/gr4vy-iOS/Gr4vyViewController.swift
+++ b/gr4vy-iOS/Gr4vyViewController.swift
@@ -74,6 +74,11 @@ public class Gr4vyViewController: UIViewController , WKNavigationDelegate {
         // Setup the WebView
         setupWKWebViewConstraints()
         setupWKWebViewJavascriptHandler()
+
+        // Make WebView inspectable via Safari dev tools
+        if webView.responds(to: Selector(("setInspectable:"))) {
+            webView.perform(Selector(("setInspectable:")), with: true)
+        }
         
         // Load the URL
         webView.navigationDelegate = self


### PR DESCRIPTION
**Description:** Supports debugging Embed while loaded in the webview with the Safari dev tools.

![Screenshot 2024-06-24 at 13 50 01](https://github.com/gr4vy/gr4vy-ios/assets/101414321/b18f2350-1893-474b-800b-84cced7c7f6d)
