### PR TITLE
fix: support connection options value dictionary

### DIFF
--- a/gr4vy-iOS/Models/Gr4vyConnectionOptionsValue.swift
+++ b/gr4vy-iOS/Models/Gr4vyConnectionOptionsValue.swift
@@ -11,6 +11,7 @@ public enum Gr4vyConnectionOptionsValue: Codable, Equatable {
     case int(Int)
     case bool(Bool)
     case double(Double)
+    case dictionary([String: String])
     
     private enum CodingError: Error {
         case unknownValue
@@ -26,6 +27,8 @@ public enum Gr4vyConnectionOptionsValue: Codable, Equatable {
             self = .double(doubleValue)
         } else if let stringValue = try? container.decode(String.self) {
             self = .string(stringValue)
+        } else if let dictionaryValue = try? container.decode([String: String].self) {
+            self = .dictionary(dictionaryValue)
         } else {
             throw CodingError.unknownValue
         }
@@ -41,6 +44,8 @@ public enum Gr4vyConnectionOptionsValue: Codable, Equatable {
         case .bool(let value):
             try container.encode(value)
         case .double(let value):
+            try container.encode(value)
+        case .dictionary(let value):
             try container.encode(value)
         }
     }

--- a/gr4vy-iOSTests/gr4vy_iOSTests.swift
+++ b/gr4vy-iOSTests/gr4vy_iOSTests.swift
@@ -894,7 +894,8 @@ class gr4vy_iOSTests: XCTestCase {
             ["key1": ["subKey1": .string("value1")], "key2": ["subKey1": .bool(true)]],
             ["key1": ["subKey1": .int(1)], "key2": ["subKey1": .bool(true)]],
             ["key1": ["subKey1": .string("value1"), "subKey2": .int(1)], "key2": ["subKey1": .int(1), "subKey2": .bool(true)]],
-            ["key1": ["subKey1": .string("value1"), "subKey2": .bool(true)], "key2": ["subKey1": .int(1), "subKey2": .string("value2")]]
+            ["key1": ["subKey1": .string("value1"), "subKey2": .bool(true)], "key2": ["subKey1": .int(1), "subKey2": .string("value2")]],
+            ["key1": ["subKey1": .dictionary(["key1": "value1"])]],
         ]
         
         for permutation in permutations {
@@ -939,6 +940,13 @@ class gr4vy_iOSTests: XCTestCase {
         
         XCTAssertEqual("window.postMessage({ \"channel\": 123, \"type\": \"updateOptions\", \"data\": {\"amount\":100,\"apiHost\":\"api.ID123.gr4vy.app\",\"apiUrl\":\"https:\\/\\/api.ID123.gr4vy.app\",\"buyerId\":\"BUYER123\",\"connectionOptions\":{\"cybersource-anti-fraud\":{\"merchant_defined_data\":\"value\"}},\"country\":\"GB\",\"currency\":\"GBP\",\"supportedApplePayVersion\":0,\"token\":\"TOKEN123\"}})", sut)
         
+        setup.connectionOptions =  [
+            "cybersource-anti-fraud": ["merchant_defined_data": .dictionary(["key": "value"])]
+        ]
+        sut = Gr4vyUtility.generateUpdateOptions(from: setup)
+        
+        XCTAssertEqual("window.postMessage({ \"channel\": 123, \"type\": \"updateOptions\", \"data\": {\"amount\":100,\"apiHost\":\"api.ID123.gr4vy.app\",\"apiUrl\":\"https:\\/\\/api.ID123.gr4vy.app\",\"buyerId\":\"BUYER123\",\"connectionOptions\":{\"cybersource-anti-fraud\":{\"merchant_defined_data\":{\"key\":\"value\"}}},\"country\":\"GB\",\"currency\":\"GBP\",\"supportedApplePayVersion\":0,\"token\":\"TOKEN123\"}})", sut)
+        
         setup.connectionOptions = [:]
         sut = Gr4vyUtility.generateUpdateOptions(from: setup)
         XCTAssertEqual("window.postMessage({ \"channel\": 123, \"type\": \"updateOptions\", \"data\": {\"amount\":100,\"apiHost\":\"api.ID123.gr4vy.app\",\"apiUrl\":\"https:\\/\\/api.ID123.gr4vy.app\",\"buyerId\":\"BUYER123\",\"connectionOptions\":{},\"country\":\"GB\",\"currency\":\"GBP\",\"supportedApplePayVersion\":0,\"token\":\"TOKEN123\"}})", sut)
@@ -958,7 +966,8 @@ class gr4vy_iOSTests: XCTestCase {
             ["key1": ["subKey1": .string("value1")], "key2": ["subKey1": .bool(true)]],
             ["key1": ["subKey1": .int(1)], "key2": ["subKey1": .bool(true)]],
             ["key1": ["subKey1": .string("value1"), "subKey2": .int(1)], "key2": ["subKey1": .int(1), "subKey2": .bool(true)]],
-            ["key1": ["subKey1": .string("value1"), "subKey2": .bool(true)], "key2": ["subKey1": .int(1), "subKey2": .string("value2")]]
+            ["key1": ["subKey1": .string("value1"), "subKey2": .bool(true)], "key2": ["subKey1": .int(1), "subKey2": .string("value2")]],
+            ["key1": ["subKey1": .dictionary(["key1": "value1"])]],
         ]
         
         for permutation in permutations {

--- a/gr4vy-ios.podspec
+++ b/gr4vy-ios.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'gr4vy-ios'
-  s.version = '2.4.0'
+  s.version = '2.4.1'
   s.license = 'MIT'
   s.summary = 'Quickly embed Gr4vy in your iOS app to store card details, authorize payments, and capture a transaction.'
   s.homepage = 'https://github.com/gr4vy/gr4vy-ios'


### PR DESCRIPTION
**Description:** After the changes here https://github.com/gr4vy/gr4vy-ios/commit/7245b8fe2b1536e97de43b1b6c2e95e4ab29e0ff, integrations passing `merchant_defined_data` with a dictionary started having issues as `Gr4vyConnectionOptionsValue` doesn't support dictionaries. This adds support so integrators can pass it this way:

```
connectionOptions: [
    "cybersource-anti-fraud": [
        "merchant_defined_data": .dictionary(["1": "2"])
    ]
]
```