### PR TITLE
chore: add the preselect store option to readme

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -44,7 +44,7 @@ jobs:
             file_to_build="$(ls -A | grep -i \\.xcodeproj\$)"
           fi
           file_to_build=$(echo $file_to_build | awk '{$1=$1;print}')
-          xcodebuild build-for-testing -scheme "$scheme" -"$filetype_parameter" "$file_to_build" -destination "platform=iOS Simulator,name=iPhone 15,OS=latest" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
+          xcodebuild build-for-testing -scheme "$scheme" -"$filetype_parameter" "$file_to_build" -destination "platform=iOS Simulator,name=iPhone 15,OS=17.2" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
 
       - name: Test
         env:
@@ -61,4 +61,4 @@ jobs:
             file_to_build="$(ls -A | grep -i \\.xcodeproj\$)"
           fi
           file_to_build=$(echo $file_to_build | awk '{$1=$1;print}')
-          xcodebuild test -scheme "$scheme" -"$filetype_parameter" "$file_to_build" -destination "platform=iOS Simulator,name=iPhone 15,OS=latest" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
+          xcodebuild test -scheme "$scheme" -"$filetype_parameter" "$file_to_build" -destination "platform=iOS Simulator,name=iPhone 15,OS=17.2" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ These are the parameteres available on the `launch` method:
 | `buyerId`                 | `Optional`      | An optional ID for a Gr4vy buyer. The transaction will automatically be associated to a buyer with that ID. If no buyer with this ID exists then it will be ignored.|
 | `presentingViewController`| **`Required`**       | The view controller presenting the Gr4vy flow. |
 | `externalIdentifier`      | `Optional`      | An optional external identifier that can be supplied. This will automatically be associated to any resource created by Gr4vy and can subsequently be used to find a resource by that ID. |
-| `store`                   | `Optional`       | `'ask'`, `true`, `false` - Explicitly store the payment method or ask the buyer, this is used when a buyerId is provided.|
+| `store`                   | `Optional`       | `'ask'`, `'preselect'`, `true`, `false` - Explicitly store the payment method, ask the buyer or preselect it by default. Requires `buyerId` or `buyerExternalIdentifier`. |
 | `display`                 | `Optional`       | `all`, `addOnly`, `storedOnly`, `supportsTokenization` - Filters the payment methods to show stored methods only, new payment methods only or methods that support tokenization.
 | `intent`                  | `Optional` | `authorize`, `preferAuthorize`, `capture` - Defines the intent of this API call. This determines the desired initial state of the transaction. When used, `preferAuthorize` automatically switches to `capture` if the selected payment method doesn't support delayed capture.|
 | `metadata`                | `Optional` | An optional dictionary of key/values for transaction metadata. All values should be a string.|

--- a/gr4vy-iOS/Models/Gr4vyStore.swift
+++ b/gr4vy-iOS/Models/Gr4vyStore.swift
@@ -7,6 +7,7 @@ import Foundation
 
 public enum Gr4vyStore: Codable {
     case ask
+    case preselect
     case `true`
     case `false`
     
@@ -15,6 +16,8 @@ public enum Gr4vyStore: Codable {
         switch self {
         case .ask:
             try container.encode("ask")
+        case .preselect:
+            try container.encode("preselect")
         case .true:
             try container.encode(true)
         case .false:


### PR DESCRIPTION
It adds the new `preselect` store option to the **Configuration** table with a concise explanation in the description column.