### PR TITLE
fix: pod build

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -44,7 +44,7 @@ jobs:
             file_to_build="$(ls -A | grep -i \\.xcodeproj\$)"
           fi
           file_to_build=$(echo $file_to_build | awk '{$1=$1;print}')
-          xcodebuild build-for-testing -scheme "$scheme" -"$filetype_parameter" "$file_to_build" -destination "platform=iOS Simulator,name=iPhone 15,OS=17.2" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
+          xcodebuild build-for-testing -scheme "$scheme" -"$filetype_parameter" "$file_to_build" -destination "platform=iOS Simulator,name=iPhone 15,OS=latest" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
 
       - name: Test
         env:
@@ -61,4 +61,4 @@ jobs:
             file_to_build="$(ls -A | grep -i \\.xcodeproj\$)"
           fi
           file_to_build=$(echo $file_to_build | awk '{$1=$1;print}')
-          xcodebuild test -scheme "$scheme" -"$filetype_parameter" "$file_to_build" -destination "platform=iOS Simulator,name=iPhone 15,OS=17.2" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
+          xcodebuild test -scheme "$scheme" -"$filetype_parameter" "$file_to_build" -destination "platform=iOS Simulator,name=iPhone 15,OS=latest" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO

--- a/gr4vy-ios.podspec
+++ b/gr4vy-ios.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'gr4vy-ios'
-  s.version = '2.4.3'
+  s.version = '2.4.4'
   s.license = 'MIT'
   s.summary = 'Quickly embed Gr4vy in your iOS app to store card details, authorize payments, and capture a transaction.'
   s.homepage = 'https://github.com/gr4vy/gr4vy-ios'


### PR DESCRIPTION
**Description:** Fixes an issue where the new version of the pod cannot be installed:

```
[!] CocoaPods could not find compatible versions for pod "gr4vy-ios":
  In snapshot (Podfile.lock):
    gr4vy-ios (= 2.4.0)

  In Podfile:
    gr4vy-embed-react-native (from `../..`) was resolved to 2.0.0, which depends on
      gr4vy-ios (= 2.4.3)

Specs satisfying the `gr4vy-ios (= 2.4.0), gr4vy-ios (= 2.4.3)` dependency were found, but they required a **higher minimum deployment target**.
```