### PR TITLE
task: use supported schemes for Apple Pay

### DIFF
--- a/gr4vy-iOS/Gr4vyUtility.swift
+++ b/gr4vy-iOS/Gr4vyUtility.swift
@@ -168,6 +168,7 @@ struct Gr4vyUtility {
         guard let data = payload["data"] as? [String: Any],
               let countryCode = data["countryCode"] as? String,
               let currencyCode = data["currencyCode"] as? String,
+              let supportedNetworks = data["supportedNetworks"] as? [String],
               let total = data["total"] as? [String: Any],
               let value = merchantName ?? total["label"] as? String,
               let amount = total["amount"] as? String else {
@@ -176,25 +177,25 @@ struct Gr4vyUtility {
         
         let paymentItem = PKPaymentSummaryItem.init(label: value, amount: NSDecimalNumber(string: amount))
         
-        let paymentNetworks = [
-            PKPaymentNetwork.amex,
-            PKPaymentNetwork.cartesBancaires,
-            PKPaymentNetwork.discover,
-            PKPaymentNetwork.eftpos,
-            PKPaymentNetwork.electron,
-            PKPaymentNetwork.elo,
-            PKPaymentNetwork.interac,
-            PKPaymentNetwork.JCB,
-            PKPaymentNetwork.mada,
-            PKPaymentNetwork.maestro,
-            PKPaymentNetwork.masterCard,
-            PKPaymentNetwork.privateLabel,
-            PKPaymentNetwork.visa,
-            PKPaymentNetwork.vPay
+        let networksMap: [String: PKPaymentNetwork] = [
+            "amex": .amex,
+            "cartesbancaires": .cartesBancaires,
+            "discover": .discover,
+            "eftpos": .eftpos,
+            "electron": .electron,
+            "elo": .elo,
+            "interac": .interac,
+            "jcb": .JCB,
+            "mada": .mada,
+            "maestro": .maestro,
+            "mastercard": .masterCard,
+            "privatelabel": .privateLabel,
+            "visa": .visa,
+            "vpay": .vPay
         ]
         
-        guard deviceSupportsApplePay(paymentNetworks: paymentNetworks) else {
-            return nil
+        let paymentNetworks = supportedNetworks.compactMap { network in
+            networksMap[network.lowercased()]
         }
         
         let request = PKPaymentRequest()

--- a/gr4vy-iOSTests/gr4vy_iOSTests.swift
+++ b/gr4vy-iOSTests/gr4vy_iOSTests.swift
@@ -748,18 +748,10 @@ class gr4vy_iOSTests: XCTestCase {
     }
     
     func testHandleAppleStartSucceeds() {
-        var payload: [String: Any] = ["data": ["countryCode": "countryCode", "currencyCode": "currencyCode", "total": ["label": "label", "amount": "123"]]]
+        var payload: [String: Any] = ["data": ["supportedNetworks": ["VISA", "MASTERCARD"], "countryCode": "countryCode", "currencyCode": "currencyCode", "total": ["label": "label", "amount": "123"]]]
         let merchantId: String = "merchantID"
         
         var sut = Gr4vyUtility.handleAppleStartSession(from: payload, merchantId: merchantId, merchantName: nil)
-        XCTAssertNotNil(sut)
-        
-        sut = Gr4vyUtility.handleAppleStartSession(from: payload, merchantId: merchantId, merchantName: "Test")
-        XCTAssertNotNil(sut)
-        
-        payload = ["data": ["supportedNetworks": ["VISA", "MASTERCARD"], "countryCode": "countryCode", "currencyCode": "currencyCode", "total": ["label": "label", "amount": "123"]]]
-        
-        sut = Gr4vyUtility.handleAppleStartSession(from: payload, merchantId: merchantId, merchantName: nil)
         XCTAssertNotNil(sut)
         
         sut = Gr4vyUtility.handleAppleStartSession(from: payload, merchantId: merchantId, merchantName: "Test")
@@ -767,7 +759,7 @@ class gr4vy_iOSTests: XCTestCase {
     }
     
     func testHandleAppleStartFails() {
-        var payload: [String: Any] = ["data": ["countryCode": "countryCode", "currencyCode": "currencyCode", "total": ["label": "label", "amount": "123"]]]
+        var payload: [String: Any] = ["data": ["supportedNetworks": ["VISA", "MASTERCARD"], "countryCode": "countryCode", "currencyCode": "currencyCode", "total": ["label": "label", "amount": "123"]]]
         let merchantId: String = "merchantID"
         
         var sut = Gr4vyUtility.handleAppleStartSession(from: payload, merchantId: merchantId, merchantName: nil)
@@ -775,6 +767,22 @@ class gr4vy_iOSTests: XCTestCase {
         
         sut = Gr4vyUtility.handleAppleStartSession(from: payload, merchantId: merchantId, merchantName: "Test")
         XCTAssertNotNil(sut)
+        
+        payload = ["data": ["supportedNetworks": [], "countryCode": "countryCode", "currencyCode": "currencyCode", "total": ["label": "label", "amount": "123"]]]
+        
+        sut = Gr4vyUtility.handleAppleStartSession(from: payload, merchantId: merchantId, merchantName: nil)
+        XCTAssertNotNil(sut)
+        
+        sut = Gr4vyUtility.handleAppleStartSession(from: payload, merchantId: merchantId, merchantName: "Test")
+        XCTAssertNotNil(sut)
+        
+        payload = ["data": ["countryCode": "countryCode", "currencyCode": "currencyCode", "total": ["label": "label", "amount": "123"]]]
+        
+        sut = Gr4vyUtility.handleAppleStartSession(from: payload, merchantId: merchantId, merchantName: nil)
+        XCTAssertNil(sut)
+        
+        sut = Gr4vyUtility.handleAppleStartSession(from: payload, merchantId: merchantId, merchantName: "Test")
+        XCTAssertNil(sut)
         
         payload = ["data": ["currencyCode": "currencyCode", "total": ["label": "label", "amount": "123"]]]
         
@@ -808,7 +816,7 @@ class gr4vy_iOSTests: XCTestCase {
         sut = Gr4vyUtility.handleAppleStartSession(from: payload, merchantId: merchantId, merchantName: "Test")
         XCTAssertNil(sut)
         
-        payload = ["data": ["countryCode": "countryCode", "currencyCode": "currencyCode", "total": ["amount": "123"]]]
+        payload = ["data": ["supportedNetworks": [], "countryCode": "countryCode", "currencyCode": "currencyCode", "total": ["amount": "123"]]]
         
         sut = Gr4vyUtility.handleAppleStartSession(from: payload, merchantId: merchantId, merchantName: nil)
         XCTAssertNil(sut)

--- a/gr4vy-ios.podspec
+++ b/gr4vy-ios.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'gr4vy-ios'
-  s.version = '2.4.4'
+  s.version = '2.5.0'
   s.license = 'MIT'
   s.summary = 'Quickly embed Gr4vy in your iOS app to store card details, authorize payments, and capture a transaction.'
   s.homepage = 'https://github.com/gr4vy/gr4vy-ios'


### PR DESCRIPTION
**Description:** Makes the SDK use the value of `supported_schemes` from `core-api` instead of allowing all the networks for Apple Pay (hardcoded that way atm).

**Ticket:** https://gr4vy.atlassian.net/browse/TA-10631

**Fixes support issue:** https://gr4vy.atlassian.net/browse/TA-10618

Open sheet with no supported cards

https://github.com/user-attachments/assets/4121c485-493a-4c08-a491-4cc54ed69bc5

Open sheet with one supported Visa card

https://github.com/user-attachments/assets/4801c3cb-4a72-4d57-b167-87210de95947