### PR TITLE
task: expose `responseCode` to `transactionFailed` event

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,8 +155,8 @@ The `onEvent` option can be used to listen to certain events emitted from the SD
 ```swift
 onEvent: { event in
  switch event {
- case .transactionFailed(let transactionID, let status, let paymentMethodID):
-     print("Handle transactionFailed here, ID: \(transactionID), Status: \(status), PaymentMethodID: \(paymentMethodID ?? "Unknown")")
+ case .transactionFailed(let transactionID, let status, let paymentMethodID, let responseCode):
+     print("Handle transactionFailed here, ID: \(transactionID), Status: \(status), PaymentMethodID: \(paymentMethodID ?? "Unknown"), ResponseCode: \(responseCode ?? "Unknown")")
      return
  case .transactionCreated(let transactionID, let status, let paymentMethodID, let approvalUrl):
      print("Handle transactionCreated here, ID: \(transactionID), Status: \(status), PaymentMethodID: \(paymentMethodID ?? "Unknown"), approvalUrl: \(approvalUrl ?? "Unknown")")

--- a/gr4vy-iOS/Gr4vy.swift
+++ b/gr4vy-iOS/Gr4vy.swift
@@ -13,7 +13,7 @@ import PassKit
 
 public enum Gr4vyEvent: Equatable {
     case transactionCreated(transactionID: String, status: String, paymentMethodID: String?, approvalUrl: String?)
-    case transactionFailed(transactionID: String, status: String, paymentMethodID: String?)
+    case transactionFailed(transactionID: String, status: String, paymentMethodID: String?, responseCode: String? = nil)
     case cancelled
     case generalError(String)
 }

--- a/gr4vy-iOS/Gr4vyUtility.swift
+++ b/gr4vy-iOS/Gr4vyUtility.swift
@@ -144,8 +144,9 @@ struct Gr4vyUtility {
         let transactionID = data["id"] as? String ?? ""
         let status = data["status"] as? String ?? ""
         let paymentMethodID = data["paymentMethodID"] as? String
+        let responseCode = data["responseCode"] as? String
         
-        return .transactionFailed(transactionID: transactionID, status: status, paymentMethodID: paymentMethodID)
+        return .transactionFailed(transactionID: transactionID, status: status, paymentMethodID: paymentMethodID, responseCode: responseCode)
     }
     
     

--- a/gr4vy-ios.podspec
+++ b/gr4vy-ios.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'gr4vy-ios'
-  s.version = '2.5.0'
+  s.version = '2.6.0'
   s.license = 'MIT'
   s.summary = 'Quickly embed Gr4vy in your iOS app to store card details, authorize payments, and capture a transaction.'
   s.homepage = 'https://github.com/gr4vy/gr4vy-ios'


### PR DESCRIPTION
**Description:** Now that we [handle request timeouts in `embed-ui`](https://github.com/gr4vy/embed-ui/pull/1237), we want to expose the `responseCode` to the `transactionFailed` event in the iOS SDK, so merchants can act on it if they want to.

**Note:** breaking change ❗ Merchants listening to these events will have to add `responseCode` as last argument in the `.transactionFailed` call (or ignore by passing `_`)

**Ticket:** https://gr4vy.atlassian.net/browse/TA-10709

**Screenshots:**

(first is a timeout, then a success, then a normal fail)

![Screenshot 2025-04-01 at 10 01 20](https://github.com/user-attachments/assets/d7107583-9a2f-48e9-bcf6-3fa9ee66992f)

new timeout error UI (as per https://github.com/gr4vy/embed-ui/pull/1237)

![Screenshot 2025-04-01 at 09 58 20](https://github.com/user-attachments/assets/c20fe489-39e5-49ce-b49e-65bc95713ed4)
