### PR TITLE
task: expose card details changed event to onevent handler

### DIFF
--- a/Gr4vy UIKit Sample App/CheckoutViewController.swift
+++ b/Gr4vy UIKit Sample App/CheckoutViewController.swift
@@ -89,6 +89,9 @@ class CheckoutViewController: UIViewController {
                 case .cancelled:
                     print("User cancelled")
                     return
+                case .cardDetailsChanged(let bin, let cardType, let scheme):
+                    print("Card details changed, BIN: \(bin), Card Type: \(cardType), Scheme: \(scheme ?? "Unknown")")
+                    return
                 }
                 
                 self.present(outcomeViewController, animated: true, completion: nil)

--- a/README.md
+++ b/README.md
@@ -211,6 +211,18 @@ Returned when the SDK encounters an error.
 
 Returned when the user cancels the SDK.
 
+#### `cardDetailsChanged`
+
+Returned when the card BIN changes in the form. It contains information on the inputted card, such as the BIN, card type and scheme.
+
+```json
+{
+  "bin": "42424242",
+  "scheme": "visa",
+  "cardType": "debit"
+}
+```
+
 
 ### Apple Pay
 

--- a/gr4vy-iOS/Gr4vy.swift
+++ b/gr4vy-iOS/Gr4vy.swift
@@ -289,7 +289,10 @@ extension Gr4vy: Gr4vyInternalDelegate {
             self.rootViewController.sendJavascriptMessage(Gr4vyUtility.generateAppleCompleteSession()) { _, _ in }
 
         case .cardDetailsChanged:
-            self.onEvent?(Gr4vyUtility.handleCardDetailsChanged(from: message.payload))
+            guard let event = Gr4vyUtility.handleCardDetailsChanged(from: message.payload) else {
+                return
+            }
+            self.onEvent?(event)
         }
     }
     

--- a/gr4vy-iOS/Gr4vy.swift
+++ b/gr4vy-iOS/Gr4vy.swift
@@ -15,6 +15,7 @@ public enum Gr4vyEvent: Equatable {
     case transactionCreated(transactionID: String, status: String, paymentMethodID: String?, approvalUrl: String?)
     case transactionFailed(transactionID: String, status: String, paymentMethodID: String?, responseCode: String? = nil)
     case cancelled
+    case cardDetailsChanged(bin: String, cardType: String, scheme: String?)
     case generalError(String)
 }
 
@@ -286,6 +287,9 @@ extension Gr4vy: Gr4vyInternalDelegate {
         case .appleCompletePayment:
             rootViewController.applePayState = .started
             self.rootViewController.sendJavascriptMessage(Gr4vyUtility.generateAppleCompleteSession()) { _, _ in }
+
+        case .cardDetailsChanged:
+            self.onEvent?(Gr4vyUtility.handleCardDetailsChanged(from: message.payload))
         }
     }
     

--- a/gr4vy-iOS/Gr4vyMessage.swift
+++ b/gr4vy-iOS/Gr4vyMessage.swift
@@ -16,6 +16,7 @@ struct Gr4vyMessage {
         case frameReady
         case approvalUrl
         case transactionCreated
+        case cardDetailsChanged
         // Embed → Embed UI
         case approvalErrored
         case transactionUpdated

--- a/gr4vy-iOS/Gr4vyUtility.swift
+++ b/gr4vy-iOS/Gr4vyUtility.swift
@@ -210,6 +210,13 @@ struct Gr4vyUtility {
         
     }
     
+    static func handleCardDetailsChanged(from payload: [String: Any]) -> Gr4vyEvent {
+        let bin = payload["bin"] as? String ?? ""
+        let cardType = payload["cardType"] as? String ?? ""
+        let scheme = payload["scheme"] as? String
+        return .cardDetailsChanged(bin: bin, cardType: cardType, scheme: scheme)
+    }
+    
     static func deviceSupportsApplePay(paymentNetworks: [PKPaymentNetwork] = [PKPaymentNetwork.amex,
                                                                               PKPaymentNetwork.cartesBancaires,
                                                                               PKPaymentNetwork.discover,

--- a/gr4vy-iOS/Gr4vyUtility.swift
+++ b/gr4vy-iOS/Gr4vyUtility.swift
@@ -210,10 +210,13 @@ struct Gr4vyUtility {
         
     }
     
-    static func handleCardDetailsChanged(from payload: [String: Any]) -> Gr4vyEvent {
-        let bin = payload["bin"] as? String ?? ""
-        let cardType = payload["cardType"] as? String ?? ""
-        let scheme = payload["scheme"] as? String
+    static func handleCardDetailsChanged(from payload: [String: Any]) -> Gr4vyEvent? {
+        guard let data = payload["data"] as? [String: Any] else {
+            return nil
+        }
+        let bin = data["bin"] as? String ?? ""
+        let cardType = data["cardType"] as? String ?? ""
+        let scheme = data["scheme"] as? String
         return .cardDetailsChanged(bin: bin, cardType: cardType, scheme: scheme)
     }
     

--- a/gr4vy-iOSTests/gr4vy_iOSTests.swift
+++ b/gr4vy-iOSTests/gr4vy_iOSTests.swift
@@ -759,12 +759,12 @@ class gr4vy_iOSTests: XCTestCase {
     }
 
     func testHandleCardDetailsChanged() {
-        var payload: [String: Any] = ["bin": "42424242", "cardType": "debit", "scheme": "visa"]
+        var payload: [String: Any] = ["data": ["bin": "42424242", "cardType": "debit", "scheme": "visa"]]
         
         var sut = Gr4vyUtility.handleCardDetailsChanged(from: payload)
         XCTAssertEqual(Gr4vyEvent.cardDetailsChanged(bin: "42424242", cardType: "debit", scheme: "visa") , sut)
 
-        payload = ["bin": "41111111", "cardType": "credit", "scheme": "visa"]
+        payload = ["data": ["bin": "41111111", "cardType": "credit", "scheme": "visa"]]
         
         sut = Gr4vyUtility.handleCardDetailsChanged(from: payload)
         XCTAssertEqual(Gr4vyEvent.cardDetailsChanged(bin: "41111111", cardType: "credit", scheme: "visa") , sut)

--- a/gr4vy-iOSTests/gr4vy_iOSTests.swift
+++ b/gr4vy-iOSTests/gr4vy_iOSTests.swift
@@ -757,6 +757,18 @@ class gr4vy_iOSTests: XCTestCase {
         sut = Gr4vyUtility.handleAppleStartSession(from: payload, merchantId: merchantId, merchantName: "Test")
         XCTAssertNotNil(sut)
     }
+
+    func testHandleCardDetailsChanged() {
+        var payload: [String: Any] = ["bin": "42424242", "cardType": "debit", "scheme": "visa"]
+        
+        var sut = Gr4vyUtility.handleCardDetailsChanged(from: payload)
+        XCTAssertEqual(Gr4vyEvent.cardDetailsChanged(bin: "42424242", cardType: "debit", scheme: "visa") , sut)
+
+        payload = ["bin": "41111111", "cardType": "credit", "scheme": "visa"]
+        
+        sut = Gr4vyUtility.handleCardDetailsChanged(from: payload)
+        XCTAssertEqual(Gr4vyEvent.cardDetailsChanged(bin: "41111111", cardType: "credit", scheme: "visa") , sut)
+    }
     
     func testHandleAppleStartFails() {
         var payload: [String: Any] = ["data": ["supportedNetworks": ["VISA", "MASTERCARD"], "countryCode": "countryCode", "currencyCode": "currencyCode", "total": ["label": "label", "amount": "123"]]]

--- a/gr4vy-ios.podspec
+++ b/gr4vy-ios.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'gr4vy-ios'
-  s.version = '2.6.0'
+  s.version = '2.7.0'
   s.license = 'MIT'
   s.summary = 'Quickly embed Gr4vy in your iOS app to store card details, authorize payments, and capture a transaction.'
   s.homepage = 'https://github.com/gr4vy/gr4vy-ios'


### PR DESCRIPTION
**Description:** Exposes the new `cardDetailsChanged` event to `onEvent` so merchants can subscribe to it. Also bumps the version to `2.7.0` (will be released separately using that value)

Depends on https://github.com/gr4vy/embed-ui/pull/1296

**Ticket:** https://gr4vy.atlassian.net/browse/TA-12026