### PR TITLE
chore: pin GitHub actions to specific commit SHA

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: maxim-lobanov/setup-xcode@v1
+      - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
         with:
           xcode-version: latest-stable
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: Set Default Scheme
         run: |


### PR DESCRIPTION

To proactively limit the impact of a compromised dependency, GitHub recommends that workflows pin dependency versions to a specific commit SHA. This will prevent malicious code added to a new or updated branch or tag from being automatically used.

In GitHub there’s a setting to “Require actions to be pinned to a full-length commit SHA” and we intend to enable this setting soon.

The changes in this PR were created using the [`pin-github-action`](https://github.com/mheap/pin-github-action) tool.


[GitHub blog post](https://github.blog/changelog/2025-08-15-github-actions-policy-now-supports-blocking-and-sha-pinning-actions/)


<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>