### PR TITLE
feat: add support for excludedMethods option

### DIFF
--- a/Gr4vy UIKit Sample App/CheckoutViewController.swift
+++ b/Gr4vy UIKit Sample App/CheckoutViewController.swift
@@ -19,8 +19,8 @@ class CheckoutViewController: UIViewController {
     @IBAction func checkout(_ sender: Any) {
         
         // TODO: Set your own token and gr4vyID here
-        let token = "eyJ0eXAiOiJKV1QiLCJraWQiOiJ4S1NGUnFBSFFSN2JkWHkwbHFEamRBanpGM0xEc01xbk56X041T3hNVHRBIiwiYWxnIjoiRVM1MTIifQ.eyJpc3MiOiJodHRwczovL2FwaS5zcGlkZXIuZ3I0dnkuYXBwLyIsImF1ZCI6Imh0dHBzOi8vYXBpLnNwaWRlci5ncjR2eS5hcHAvIiwianRpIjoiZTYwNjFiNmUtNTk2YS00YzhhLTkxMTUtODJkMGEwOWMxNDQ3Iiwic3ViIjoiMTA4M2NjOGItMGM0OC00NzkwLTlhM2UtOWNlNWM3NjU1YTI1OjAiLCJleHAiOjE3ODAwNzQwMDcsIm5iZiI6MTc4MDA3MzcwNywiaWF0IjoxNzgwMDczNzA3LCJzY29wZXMiOlsiKi5yZWFkIiwiKi53cml0ZSIsImFwaS1rZXktcGFpcnMucmVhZCIsImFwaS1rZXktcGFpcnMud3JpdGUiLCJoZWFsdGgtZGFzaGJvYXJkLnJlYWQiLCJoZWFsdGgtZGFzaGJvYXJkLndyaXRlIiwibWV0cmljcy1leHBsb3Jlci5yZWFkIiwibWV0cmljcy1leHBsb3Jlci53cml0ZSIsIm1vbml0b3JpbmcucmVhZCIsIm1vbml0b3Jpbmcud3JpdGUiLCJwYXltZW50LWxpbmtzLnJlYWQiLCJzZXNzaW9ucy53cml0ZSIsInVzZXJzLm1lLnJlYWQiLCJ1c2Vycy5tZS53cml0ZSIsInVzZXJzLnJlYWQiLCJ1c2Vycy53cml0ZSJdLCJpc19zdGFmZiI6ZmFsc2V9.AQiXBXAAS-_bT644TIpZtEH3fmTUN6XiN6nQNbJTBvwSN9kFzUcOf06Mc_WeijnEKACLo5yW0Lh4JNlUQGEo3g5lAG8CytLVlVz8Pv_2glOKxMvY70NqyYxXlRY3Y8obTpuEZnt6IUngD8mHzwFTZPKqyRRHpMQAudQHQ_amcjqdQf1r"
-        let gr4vyId = "spider"
+        let token = "<TOKEN HERE>"
+        let gr4vyId = "<GR4VY ID HERE>"
         
         var categories = [String]()
         categories.append("test")

--- a/Gr4vy UIKit Sample App/CheckoutViewController.swift
+++ b/Gr4vy UIKit Sample App/CheckoutViewController.swift
@@ -19,8 +19,8 @@ class CheckoutViewController: UIViewController {
     @IBAction func checkout(_ sender: Any) {
         
         // TODO: Set your own token and gr4vyID here
-        let token = "<TOKEN HERE>"
-        let gr4vyId = "<GR4VY ID HERE>"
+        let token = "eyJ0eXAiOiJKV1QiLCJraWQiOiJ4S1NGUnFBSFFSN2JkWHkwbHFEamRBanpGM0xEc01xbk56X041T3hNVHRBIiwiYWxnIjoiRVM1MTIifQ.eyJpc3MiOiJodHRwczovL2FwaS5zcGlkZXIuZ3I0dnkuYXBwLyIsImF1ZCI6Imh0dHBzOi8vYXBpLnNwaWRlci5ncjR2eS5hcHAvIiwianRpIjoiZTYwNjFiNmUtNTk2YS00YzhhLTkxMTUtODJkMGEwOWMxNDQ3Iiwic3ViIjoiMTA4M2NjOGItMGM0OC00NzkwLTlhM2UtOWNlNWM3NjU1YTI1OjAiLCJleHAiOjE3ODAwNzQwMDcsIm5iZiI6MTc4MDA3MzcwNywiaWF0IjoxNzgwMDczNzA3LCJzY29wZXMiOlsiKi5yZWFkIiwiKi53cml0ZSIsImFwaS1rZXktcGFpcnMucmVhZCIsImFwaS1rZXktcGFpcnMud3JpdGUiLCJoZWFsdGgtZGFzaGJvYXJkLnJlYWQiLCJoZWFsdGgtZGFzaGJvYXJkLndyaXRlIiwibWV0cmljcy1leHBsb3Jlci5yZWFkIiwibWV0cmljcy1leHBsb3Jlci53cml0ZSIsIm1vbml0b3JpbmcucmVhZCIsIm1vbml0b3Jpbmcud3JpdGUiLCJwYXltZW50LWxpbmtzLnJlYWQiLCJzZXNzaW9ucy53cml0ZSIsInVzZXJzLm1lLnJlYWQiLCJ1c2Vycy5tZS53cml0ZSIsInVzZXJzLnJlYWQiLCJ1c2Vycy53cml0ZSJdLCJpc19zdGFmZiI6ZmFsc2V9.AQiXBXAAS-_bT644TIpZtEH3fmTUN6XiN6nQNbJTBvwSN9kFzUcOf06Mc_WeijnEKACLo5yW0Lh4JNlUQGEo3g5lAG8CytLVlVz8Pv_2glOKxMvY70NqyYxXlRY3Y8obTpuEZnt6IUngD8mHzwFTZPKqyRRHpMQAudQHQ_amcjqdQf1r"
+        let gr4vyId = "spider"
         
         var categories = [String]()
         categories.append("test")
@@ -77,7 +77,7 @@ class CheckoutViewController: UIViewController {
                 let outcomeViewController = OutcomeViewController(nibName: "OutcomeViewController",
                                                                   bundle:  nil)
                 switch event {
-                case .transactionFailed(let transactionID, let status, let paymentMethodID):
+                case .transactionFailed(let transactionID, let status, let paymentMethodID, _):
                     print("Handle transactionFailed here, ID: \(transactionID), Status: \(status), PaymentMethodID: \(paymentMethodID ?? "Unknown")")
                     outcomeViewController.outcome = .failure(reason: "transactionFailed")
                 case .transactionCreated(let transactionID, let status, let paymentMethodID, let approvalUrl):

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ These are the parameteres available on the `launch` method:
 | `connectionOptionsString`| `Optional`       | A JSON String of connectionOptions |
 | `buyer`| `Optional`       | An optional buyer object to allow guest checkout (see https://docs.gr4vy.com/reference/transactions/new-transaction) |
 | `installmentCount` | `number` | An optional value that indicates the number of installments a buyer is required to make. |
+| `excludedMethods` | `Optional` | An optional list of payment methods to exclude. |
 | `debugMode`| `Optional`       | `true`, `false`. Defaults to `false`, this prints to the console. |
 | `onEvent`                 | `Optional`      | **Please see below for more details.** |
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ These are the parameteres available on the `launch` method:
 | `connectionOptionsString`| `Optional`       | A JSON String of connectionOptions |
 | `buyer`| `Optional`       | An optional buyer object to allow guest checkout (see https://docs.gr4vy.com/reference/transactions/new-transaction) |
 | `installmentCount` | `number` | An optional value that indicates the number of installments a buyer is required to make. |
-| `excludedMethods` | `Optional` | An optional list of payment methods to exclude. |
+| `excludedMethods` | `Optional` | An optional list of payment methods to exclude (pass via `Gr4vy.init(...)`). |
 | `debugMode`| `Optional`       | `true`, `false`. Defaults to `false`, this prints to the console. |
 | `onEvent`                 | `Optional`      | **Please see below for more details.** |
 

--- a/gr4vy-iOS/Gr4vy.swift
+++ b/gr4vy-iOS/Gr4vy.swift
@@ -63,7 +63,8 @@ public class Gr4vy {
                  buyer: Gr4vyBuyer? = nil,
                  debugMode: Bool = false,
                  onEvent: Gr4vyCompletionHandler? = nil,
-                 installmentCount: Int? = nil) {
+                 installmentCount: Int? = nil,
+                 excludedMethods: [String]? = nil) {
         
         self.setup = Gr4vySetup(gr4vyId: gr4vyId,
                                 token: token,
@@ -90,7 +91,8 @@ public class Gr4vy {
                                 merchantAccountId: merchantAccountId,
                                 connectionOptions: Gr4vyUtility.getConnectionOptions(from: connectionOptions, connectionOptionsString: connectionOptionsString),
                                 buyer: buyer,
-                                installmentCount: installmentCount)
+                                installmentCount: installmentCount,
+                                excludedMethods: excludedMethods)
         
         self.debugMode = debugMode
         self.onEvent = onEvent

--- a/gr4vy-iOS/Models/Gr4vySetup.swift
+++ b/gr4vy-iOS/Models/Gr4vySetup.swift
@@ -35,6 +35,7 @@ struct Gr4vySetup: Encodable {
     var apiUrl: String?
     var supportedApplePayVersion: Int = 0
     var installmentCount: Int?
+    var excludedMethods: [String]?
     var instance: String {
         return environment == .production ? gr4vyId : "sandbox.\(gr4vyId)"
     }
@@ -65,9 +66,10 @@ struct Gr4vySetup: Encodable {
         case apiUrl
         case supportedApplePayVersion
         case installmentCount
+        case excludedMethods
     }
     
-    public init(gr4vyId: String, token: String, amount: Int, currency: String, country: String, buyerId: String? = nil, environment: Gr4vyEnvironment, externalIdentifier: String? = nil, store: Gr4vyStore? = nil, display: String? = nil, intent: String? = nil, metadata: [String : String]? = nil, paymentSource: Gr4vyPaymentSource? = nil, cartItems: [Gr4vyCartItem]? = nil, applePayMerchantId: String? = nil, applePayMerchantName: String? = nil, theme: Gr4vyTheme? = nil, buyerExternalIdentifier: String? = nil, locale: String? = nil, statementDescriptor: Gr4vyStatementDescriptor? = nil, requireSecurityCode: Bool? = nil, shippingDetailsId: String? = nil, merchantAccountId: String? = nil, connectionOptions: [String: [String: Gr4vyConnectionOptionsValue]]? = nil, buyer: Gr4vyBuyer? = nil, installmentCount: Int? = nil) {
+    public init(gr4vyId: String, token: String, amount: Int, currency: String, country: String, buyerId: String? = nil, environment: Gr4vyEnvironment, externalIdentifier: String? = nil, store: Gr4vyStore? = nil, display: String? = nil, intent: String? = nil, metadata: [String : String]? = nil, paymentSource: Gr4vyPaymentSource? = nil, cartItems: [Gr4vyCartItem]? = nil, applePayMerchantId: String? = nil, applePayMerchantName: String? = nil, theme: Gr4vyTheme? = nil, buyerExternalIdentifier: String? = nil, locale: String? = nil, statementDescriptor: Gr4vyStatementDescriptor? = nil, requireSecurityCode: Bool? = nil, shippingDetailsId: String? = nil, merchantAccountId: String? = nil, connectionOptions: [String: [String: Gr4vyConnectionOptionsValue]]? = nil, buyer: Gr4vyBuyer? = nil, installmentCount: Int? = nil, excludedMethods: [String]? = nil) {
         self.gr4vyId = gr4vyId
         self.token = token
         self.amount = amount
@@ -94,5 +96,6 @@ struct Gr4vySetup: Encodable {
         self.connectionOptions = connectionOptions
         self.buyer = buyer
         self.installmentCount = installmentCount
+        self.excludedMethods = excludedMethods
     }
 }

--- a/gr4vy-iOSTests/gr4vy_iOSTests.swift
+++ b/gr4vy-iOSTests/gr4vy_iOSTests.swift
@@ -1205,6 +1205,34 @@ class gr4vy_iOSTests: XCTestCase {
         sut = Gr4vyUtility.generateUpdateOptions(from: setup)
         XCTAssertEqual("window.postMessage({ \"channel\": 123, \"type\": \"updateOptions\", \"data\": {\"amount\":100,\"apiHost\":\"api.ID123.gr4vy.app\",\"apiUrl\":\"https:\\/\\/api.ID123.gr4vy.app\",\"buyer\":{\"shippingDetails\":{\"address\":{\"city\":\"city\",\"country\":\"country\",\"houseNumberOrName\":\"houseNumberOrName\",\"line1\":\"line1\",\"line2\":\"line2\",\"organization\":\"organization\",\"postalCode\":\"postalCode\",\"state\":\"state\",\"stateCode\":\"stateCode\"},\"firstName\":\"firstName\",\"lastName\":\"lastName\"}},\"country\":\"GB\",\"currency\":\"GBP\",\"supportedApplePayVersion\":0,\"token\":\"TOKEN123\"}})", sut)
     }
+
+    func testGenerateUpdateOptionsWithExcludedMethods() {
+        setup.environment = .production
+        setup.gr4vyId = "ID123"
+        setup.token = "TOKEN123"
+        setup.amount = 100
+        setup.country = "GB"
+        setup.currency = "GBP"
+        setup.buyerId = nil
+        setup.excludedMethods = ["card", "paypal"]
+
+        let sut = Gr4vyUtility.generateUpdateOptions(from: setup)
+        XCTAssertTrue(sut.contains("\"excludedMethods\":[\"card\",\"paypal\"]"))
+    }
+
+    func testGenerateUpdateOptionsWithoutExcludedMethods() {
+        setup.environment = .production
+        setup.gr4vyId = "ID123"
+        setup.token = "TOKEN123"
+        setup.amount = 100
+        setup.country = "GB"
+        setup.currency = "GBP"
+        setup.buyerId = nil
+        setup.excludedMethods = nil
+
+        let sut = Gr4vyUtility.generateUpdateOptions(from: setup)
+        XCTAssertFalse(sut.contains("excludedMethods"))
+    }
 }
 
 extension gr4vy_iOSTests {

--- a/gr4vy-iOSTests/gr4vy_iOSTests.swift
+++ b/gr4vy-iOSTests/gr4vy_iOSTests.swift
@@ -1231,7 +1231,7 @@ class gr4vy_iOSTests: XCTestCase {
         setup.excludedMethods = nil
 
         let sut = Gr4vyUtility.generateUpdateOptions(from: setup)
-        XCTAssertFalse(sut.contains("excludedMethods"))
+        XCTAssertEqual("window.postMessage({ \"channel\": 123, \"type\": \"updateOptions\", \"data\": {\"amount\":100,\"apiHost\":\"api.ID123.gr4vy.app\",\"apiUrl\":\"https:\\/\\/api.ID123.gr4vy.app\",\"country\":\"GB\",\"currency\":\"GBP\",\"supportedApplePayVersion\":0,\"token\":\"TOKEN123\"}})", sut)
     }
 }
 

--- a/gr4vy-ios.podspec
+++ b/gr4vy-ios.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'gr4vy-ios'
-  s.version = '2.8.0'
+  s.version = '2.9.0'
   s.license = 'MIT'
   s.summary = 'Quickly embed Gr4vy in your iOS app to store card details, authorize payments, and capture a transaction.'
   s.homepage = 'https://github.com/gr4vy/gr4vy-ios'


### PR DESCRIPTION
Adds the `excludedMethods` option to the iOS SDK, matching the existing parameter in the web Embed, plus a small sample-app fix. The version bump is included so no separate release PR is needed.

## Feature — excludedMethods

- Add `excludedMethods: [String]?` to `Gr4vySetup` (property + `CodingKeys` entry + initializer parameter)
- Expose `excludedMethods` on the public `Gr4vy.init(...)` API
- Serialization is handled automatically by Swift `Codable` — `nil` is omitted from the emitted JSON
- Two new unit tests: value present in the `updateOptions` payload when set, absent when `nil`
- Document the option in the README parameters table

## Sample app fix

- Update the UIKit sample app `transactionFailed` pattern match to handle the new `responseCode` associated value (`CheckoutViewController.swift`)

## Release

- Bump podspec `s.version` `2.8.0` → `2.9.0` so this PR can be tagged `2.9.0` on merge without a follow-up bump PR