### PR TITLE
task: add approvalExpiresAt support

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -44,7 +44,7 @@ jobs:
             file_to_build="$(ls -A | grep -i \\.xcodeproj\$)"
           fi
           file_to_build=$(echo $file_to_build | awk '{$1=$1;print}')
-          xcodebuild build-for-testing -scheme "$scheme" -"$filetype_parameter" "$file_to_build" -destination "platform=iOS Simulator,name=iPhone 16" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
+          xcodebuild build-for-testing -scheme "$scheme" -"$filetype_parameter" "$file_to_build" -destination "platform=iOS Simulator,name=iPhone 17" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
 
       - name: Test
         env:
@@ -61,4 +61,4 @@ jobs:
             file_to_build="$(ls -A | grep -i \\.xcodeproj\$)"
           fi
           file_to_build=$(echo $file_to_build | awk '{$1=$1;print}')
-          xcodebuild test -scheme "$scheme" -"$filetype_parameter" "$file_to_build" -destination "platform=iOS Simulator,name=iPhone 16" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
+          xcodebuild test -scheme "$scheme" -"$filetype_parameter" "$file_to_build" -destination "platform=iOS Simulator,name=iPhone 17" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -44,7 +44,7 @@ jobs:
             file_to_build="$(ls -A | grep -i \\.xcodeproj\$)"
           fi
           file_to_build=$(echo $file_to_build | awk '{$1=$1;print}')
-          xcodebuild build-for-testing -scheme "$scheme" -"$filetype_parameter" "$file_to_build" -destination "platform=iOS Simulator,name=iPhone 16,OS=18.6" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
+          xcodebuild build-for-testing -scheme "$scheme" -"$filetype_parameter" "$file_to_build" -destination "platform=iOS Simulator,name=iPhone 16" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
 
       - name: Test
         env:
@@ -61,4 +61,4 @@ jobs:
             file_to_build="$(ls -A | grep -i \\.xcodeproj\$)"
           fi
           file_to_build=$(echo $file_to_build | awk '{$1=$1;print}')
-          xcodebuild test -scheme "$scheme" -"$filetype_parameter" "$file_to_build" -destination "platform=iOS Simulator,name=iPhone 16,OS=18.6" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
+          xcodebuild test -scheme "$scheme" -"$filetype_parameter" "$file_to_build" -destination "platform=iOS Simulator,name=iPhone 16" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ These are the parameteres available on the `launch` method:
 | `buyer`| `Optional`       | An optional buyer object to allow guest checkout (see https://docs.gr4vy.com/reference/transactions/new-transaction) |
 | `installmentCount` | `number` | An optional value that indicates the number of installments a buyer is required to make. |
 | `excludedMethods` | `Optional` | An optional list of payment methods to exclude (pass via `Gr4vy.init(...)`). |
+| `approvalExpiresAt` | `Optional` | An optional datetime string (ISO 8601 format recommended) that sets the expiration date for transaction approval. If set to `null`, it is treated the same as if it were omitted. |
 | `debugMode`| `Optional`       | `true`, `false`. Defaults to `false`, this prints to the console. |
 | `onEvent`                 | `Optional`      | **Please see below for more details.** |
 

--- a/gr4vy-iOS/Gr4vy.swift
+++ b/gr4vy-iOS/Gr4vy.swift
@@ -64,7 +64,8 @@ public class Gr4vy {
                  debugMode: Bool = false,
                  onEvent: Gr4vyCompletionHandler? = nil,
                  installmentCount: Int? = nil,
-                 excludedMethods: [String]? = nil) {
+                 excludedMethods: [String]? = nil,
+                 approvalExpiresAt: String? = nil) {
         
         self.setup = Gr4vySetup(gr4vyId: gr4vyId,
                                 token: token,
@@ -92,7 +93,8 @@ public class Gr4vy {
                                 connectionOptions: Gr4vyUtility.getConnectionOptions(from: connectionOptions, connectionOptionsString: connectionOptionsString),
                                 buyer: buyer,
                                 installmentCount: installmentCount,
-                                excludedMethods: excludedMethods)
+                                excludedMethods: excludedMethods,
+                                approvalExpiresAt: approvalExpiresAt)
         
         self.debugMode = debugMode
         self.onEvent = onEvent

--- a/gr4vy-iOS/Models/Gr4vySetup.swift
+++ b/gr4vy-iOS/Models/Gr4vySetup.swift
@@ -36,6 +36,7 @@ struct Gr4vySetup: Encodable {
     var supportedApplePayVersion: Int = 0
     var installmentCount: Int?
     var excludedMethods: [String]?
+    var approvalExpiresAt: String?
     var instance: String {
         return environment == .production ? gr4vyId : "sandbox.\(gr4vyId)"
     }
@@ -67,9 +68,10 @@ struct Gr4vySetup: Encodable {
         case supportedApplePayVersion
         case installmentCount
         case excludedMethods
+        case approvalExpiresAt
     }
     
-    public init(gr4vyId: String, token: String, amount: Int, currency: String, country: String, buyerId: String? = nil, environment: Gr4vyEnvironment, externalIdentifier: String? = nil, store: Gr4vyStore? = nil, display: String? = nil, intent: String? = nil, metadata: [String : String]? = nil, paymentSource: Gr4vyPaymentSource? = nil, cartItems: [Gr4vyCartItem]? = nil, applePayMerchantId: String? = nil, applePayMerchantName: String? = nil, theme: Gr4vyTheme? = nil, buyerExternalIdentifier: String? = nil, locale: String? = nil, statementDescriptor: Gr4vyStatementDescriptor? = nil, requireSecurityCode: Bool? = nil, shippingDetailsId: String? = nil, merchantAccountId: String? = nil, connectionOptions: [String: [String: Gr4vyConnectionOptionsValue]]? = nil, buyer: Gr4vyBuyer? = nil, installmentCount: Int? = nil, excludedMethods: [String]? = nil) {
+    public init(gr4vyId: String, token: String, amount: Int, currency: String, country: String, buyerId: String? = nil, environment: Gr4vyEnvironment, externalIdentifier: String? = nil, store: Gr4vyStore? = nil, display: String? = nil, intent: String? = nil, metadata: [String : String]? = nil, paymentSource: Gr4vyPaymentSource? = nil, cartItems: [Gr4vyCartItem]? = nil, applePayMerchantId: String? = nil, applePayMerchantName: String? = nil, theme: Gr4vyTheme? = nil, buyerExternalIdentifier: String? = nil, locale: String? = nil, statementDescriptor: Gr4vyStatementDescriptor? = nil, requireSecurityCode: Bool? = nil, shippingDetailsId: String? = nil, merchantAccountId: String? = nil, connectionOptions: [String: [String: Gr4vyConnectionOptionsValue]]? = nil, buyer: Gr4vyBuyer? = nil, installmentCount: Int? = nil, excludedMethods: [String]? = nil, approvalExpiresAt: String? = nil) {
         self.gr4vyId = gr4vyId
         self.token = token
         self.amount = amount
@@ -97,5 +99,6 @@ struct Gr4vySetup: Encodable {
         self.buyer = buyer
         self.installmentCount = installmentCount
         self.excludedMethods = excludedMethods
+        self.approvalExpiresAt = approvalExpiresAt
     }
 }

--- a/gr4vy-ios.podspec
+++ b/gr4vy-ios.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'gr4vy-ios'
-  s.version = '2.9.0'
+  s.version = '2.10.0'
   s.license = 'MIT'
   s.summary = 'Quickly embed Gr4vy in your iOS app to store card details, authorize payments, and capture a transaction.'
   s.homepage = 'https://github.com/gr4vy/gr4vy-ios'


### PR DESCRIPTION
**Description:** Adds support for `approvalExpiresAt`, similar to https://github.com/gr4vy/gr4vy-android/pull/33. Also fixes a [CI error](https://github.com/gr4vy/gr4vy-ios/actions/runs/29732130409/job/88318810496?pr=28) due to updated xcode runner image:

```
xcodebuild: error: Unable to find a device matching the provided destination specifier:
		{ platform:iOS Simulator, OS:18.6, name:iPhone 16 }

	The requested device could not be found because no available devices matched the request.
```

**Ticket:** https://gr4vy.atlassian.net/browse/TA-17917

Test on spider with SPEI and a value of `2026-07-20T09:35:00Z`

transaction before expiry https://sandbox.spider.gr4vy.app/merchants/default/transactions/c9069fd6-6845-41c7-b007-e3dc924a688b/overview

error after expiry

<img width="585" height="271" alt="Screenshot 2026-07-20 at 11 37 40" src="https://github.com/user-attachments/assets/d991d58c-a7db-4ff1-98c3-69f77a33f9a9" />
